### PR TITLE
feat(notify): 支持通过环境变量配置通知功能

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,5 @@
+version: "1"
+rules:
+  - base: upstream
+    upstream: naomi233:master # change `wei` to the owner of upstream repo
+    mergeMethod: merge

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .vscode/
 .claude/
 !.claude/index.json
+.serena
 
 vendor/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.3-alpine AS builder
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,14 @@ WORKDIR /app
 
 RUN apk add --no-cache tzdata ca-certificates
 
+ENV TZ=UTC
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --from=builder /out/watchducker /app/watchducker
 COPY push.yaml.example /app
 
-RUN chmod +x /app/watchducker && \
+RUN chmod +x /app/watchducker /usr/local/bin/entrypoint.sh && \
     ln -s /app/watchducker /usr/local/bin/watchducker
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["watchducker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,25 @@
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
+
+WORKDIR /src
+
+RUN apk add --no-cache git
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -o /out/watchducker .
+
 FROM alpine:latest
 
 WORKDIR /app
-ARG TARGETPLATFORM
 
-RUN apk add --no-cache tzdata
+RUN apk add --no-cache tzdata ca-certificates
 
-COPY $TARGETPLATFORM/watchducker /app
+COPY --from=builder /out/watchducker /app/watchducker
 COPY push.yaml.example /app
 
 RUN chmod +x /app/watchducker && \

--- a/README.md
+++ b/README.md
@@ -224,7 +224,14 @@ export WATCHDUCKER_CRON="0 2 * * *"
 
 # 设置日志级别 (DEBUG/INFO/WARN/ERROR)
 export WATCHDUCKER_LOG_LEVEL=DEBUG
+
+# 设置容器时区（默认 UTC，可按需覆盖）
+export TZ=Asia/Shanghai
 ```
+
+### 时区配置
+
+容器镜像默认按照 UTC 运行。只需通过标准 `TZ` 环境变量（如 `-e TZ=Asia/Shanghai`，或在 Compose/环境配置中设置 `TZ`）即可让容器启动时自动切换到目标时区，无需额外挂载 `/etc/localtime`。
 
 ### 使用标签驱动更新
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ services:
 
 - `--label`: 检查所有带有 `watchducker.update=true` 标签的容器
 - `--no-restart`: 只更新镜像，不重启容器
-- `--all`: 检查所有容器
+- `--all`: 检查所有容器（默认仅包含运行中的容器）
+- `--include-stopped`: 在检查时包含已停止的容器
 - `--clean`: 更新容器后自动清理悬空镜像
 - `--cron`: 定时执行，使用标准 [cron 表达式](https://crontab.guru) 格式，默认 "0 2 * * *"
 - `--once`: 只执行一次检查和更新，然后退出
@@ -206,8 +207,11 @@ services:
 # 等同于 --label 选项
 export WATCHDUCKER_LABEL=true
 
-# 等同于 --label 选项
+# 等同于 --all 选项
 export WATCHDUCKER_ALL=true
+
+# 等同于 --include-stopped 选项
+export WATCHDUCKER_INCLUDE_STOPPED=true
 
 # 等同于 --no-restart 选项
 export WATCHDUCKER_NO_RESTART=true

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -89,7 +89,7 @@ func RunChecker(ctx context.Context, checkFunc func(*core.Checker) (*types.Batch
 	cfg := config.Get()
 
 	// 创建检查器
-	checker, err := core.NewChecker()
+	checker, err := core.NewChecker(cfg.IncludeStopped())
 	if err != nil {
 		logger.Fatal("创建检查器失败: %v", err)
 	}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+TZ_VALUE="${TZ:-UTC}"
+ZONEINFO_PATH="/usr/share/zoneinfo/${TZ_VALUE}"
+
+if [ -f "$ZONEINFO_PATH" ]; then
+  ln -snf "$ZONEINFO_PATH" /etc/localtime
+  echo "$TZ_VALUE" >/etc/timezone
+else
+  echo "Warning: timezone '${TZ_VALUE}' not found, falling back to UTC" >&2
+  ln -snf /usr/share/zoneinfo/UTC /etc/localtime
+  echo "UTC" >/etc/timezone
+fi
+
+exec "$@"

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -38,12 +38,12 @@ func (cs *ContainerService) createContainerInfo(container dockerTypes.Container,
 }
 
 // GetByName 根据容器名称获取容器信息
-func (cs *ContainerService) GetByName(ctx context.Context, containerNames []string) ([]types.ContainerInfo, error) {
+func (cs *ContainerService) GetByName(ctx context.Context, containerNames []string, includeStopped bool) ([]types.ContainerInfo, error) {
 	cli := cs.clientManager.GetClient()
 
 	// 获取所有容器列表
 	containers, err := cli.ContainerList(ctx, container.ListOptions{
-		All: true, // 包括停止的容器
+		All: includeStopped,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("获取容器列表失败: %w", err)
@@ -73,7 +73,7 @@ func (cs *ContainerService) GetByName(ctx context.Context, containerNames []stri
 }
 
 // GetByLabel 根据标签获取容器信息
-func (cs *ContainerService) GetByLabel(ctx context.Context, labelKey, labelValue string) ([]types.ContainerInfo, error) {
+func (cs *ContainerService) GetByLabel(ctx context.Context, labelKey, labelValue string, includeStopped bool) ([]types.ContainerInfo, error) {
 	cli := cs.clientManager.GetClient()
 
 	filter := filters.NewArgs()
@@ -86,7 +86,7 @@ func (cs *ContainerService) GetByLabel(ctx context.Context, labelKey, labelValue
 	}
 
 	containers, err := cli.ContainerList(ctx, container.ListOptions{
-		All:     true, // 包括停止的容器
+		All:     includeStopped,
 		Filters: filter,
 	})
 	if err != nil {
@@ -106,21 +106,6 @@ func (cs *ContainerService) GetByLabel(ctx context.Context, labelKey, labelValue
 	}
 
 	return result, nil
-}
-
-// ExtractUniqueImages 从容器列表中提取唯一的镜像名称
-func (cs *ContainerService) ExtractUniqueImages(containers []types.ContainerInfo) []string {
-	imageSet := make(map[string]struct{})
-	var images []string
-
-	for _, container := range containers {
-		if _, exists := imageSet[container.Image]; !exists {
-			imageSet[container.Image] = struct{}{}
-			images = append(images, container.Image)
-		}
-	}
-
-	return images
 }
 
 // StopContainer 停止容器
@@ -195,12 +180,12 @@ func (cos *ContainerService) CreateContainer(ctx context.Context, config *contai
 }
 
 // GetAll 获取所有容器信息
-func (cs *ContainerService) GetAll(ctx context.Context) ([]types.ContainerInfo, error) {
+func (cs *ContainerService) GetAll(ctx context.Context, includeStopped bool) ([]types.ContainerInfo, error) {
 	cli := cs.clientManager.GetClient()
 
 	// 获取所有容器列表
 	containers, err := cli.ContainerList(ctx, container.ListOptions{
-		All: true, // 包括停止的容器
+		All: includeStopped,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("获取容器列表失败: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	noRestart      bool     `mapstructure:"no_restart"`
 	cleanUp        bool     `mapstructure:"clean_up"`
 	logLevel       string   `mapstructure:"log_level"`
+	includeStopped bool     `mapstructure:"include_stopped"`
 }
 
 // 全局配置实例（只读，初始化后不可修改）
@@ -85,6 +86,11 @@ func (c *Config) CleanUp() bool {
 	return c.cleanUp
 }
 
+// IncludeStopped 获取 IncludeStopped 配置
+func (c *Config) IncludeStopped() bool {
+	return c.includeStopped
+}
+
 // loadConfig 执行实际的配置加载逻辑
 func loadConfig() (*Config, error) {
 	// 创建 Viper 实例
@@ -98,6 +104,7 @@ func loadConfig() (*Config, error) {
 	v.SetDefault("no-restart", false)
 	v.SetDefault("cron", "0 2 * * *")
 	v.SetDefault("clean", false)
+	v.SetDefault("include-stopped", false)
 
 	// 设置命令行参数
 	pflag.Bool("label", false, "检查所有带有 watchducker.update=true 标签的容器")
@@ -106,6 +113,7 @@ func loadConfig() (*Config, error) {
 	pflag.Bool("once", false, "只执行一次检查和更新，然后退出")
 	pflag.String("cron", "0 2 * * *", "定时执行，使用标准 cron 表达式格式")
 	pflag.Bool("clean", false, "更新容器后自动清理悬空镜像")
+	pflag.Bool("include-stopped", false, "检查时包含已停止的容器")
 
 	// 解析命令行参数
 	pflag.Parse()
@@ -124,6 +132,7 @@ func loadConfig() (*Config, error) {
 		containerNames: pflag.Args(),
 		cleanUp:        v.GetBool("clean"),
 		logLevel:       v.GetString("LOG_LEVEL"),
+		includeStopped: v.GetBool("include-stopped"),
 	}
 
 	// 设置日志级别
@@ -162,6 +171,7 @@ func PrintUsage() {
 	fmt.Println("  --cron        定时执行，使用标准 cron 表达式格式，默认为 \"0 2 * * *\"")
 	fmt.Println("  --once        只执行一次检查和更新，然后退出")
 	fmt.Println("  --clean       更新容器后自动清理悬空镜像")
+	fmt.Println("  --include-stopped 检查时包含已停止的容器（默认仅检查运行中容器）")
 	fmt.Println()
 	fmt.Println("环境变量:")
 	fmt.Println("  WATCHDUCKER_LABEL        等同于 --label 选项")
@@ -169,6 +179,7 @@ func PrintUsage() {
 	fmt.Println("  WATCHDUCKER_NO_RESTART   等同于 --no-restart 选项")
 	fmt.Println("  WATCHDUCKER_CRON         等同于 --cron 选项，默认为 0 2 * * *")
 	fmt.Println("  WATCHDUCKER_CLEAN        等同于 --clean 选项")
+	fmt.Println("  WATCHDUCKER_INCLUDE_STOPPED  等同于 --include-stopped 选项")
 	fmt.Println("  WATCHDUCKER_LOG_LEVEL    设置日志级别 (DEBUG/INFO/WARN/ERROR)")
 	fmt.Println()
 	fmt.Println("参数:")

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -117,6 +117,11 @@ func loadConfig(configPath string) error {
 	v.SetConfigFile(configPath)
 	v.SetConfigType("yaml")
 
+	// 支持环境变量，前缀为 WATCHDUCKER_
+	v.SetEnvPrefix("WATCHDUCKER")
+	v.AutomaticEnv()
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
 	if err := v.ReadInConfig(); err != nil {
 		logger.Error("配置文件读取失败: %v", err)
 	}

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/smtp"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 	"watchducker/pkg/logger"


### PR DESCRIPTION
新增对环境变量的支持，允许用户通过设置 `WATCHDUCKER_*` 前缀的环境变量来配置通知服务， 而无需挂载 `push.yaml` 配置文件。环境变量会覆盖配置文件中的相同配置项。
增加时区设置
同时增加“--include-stopped”变量控制是否更新已停止的容器镜像